### PR TITLE
Remove @ez-elements/jsx from ez-elements

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ez-elements/core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "code-prettify": "^0.1.0",
-    "ez-elements": "^0.0.4"
+    "ez-elements": "^0.0.5",
+    "@ez-elements/jsx": "^0.0.5"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.3",

--- a/examples/src/button-example/ButtonExample.ts
+++ b/examples/src/button-example/ButtonExample.ts
@@ -6,7 +6,6 @@ export function ButtonExample() {
 
   return ez('div').append(
     (statusElement = new StatusElement(false)),
-
     ez('button')
       .setTextContent('Enable')
       .onClick(() => {

--- a/examples/src/ez-button-example/EZButtonExample.ts
+++ b/examples/src/ez-button-example/EZButtonExample.ts
@@ -6,7 +6,6 @@ export function EZButtonExample() {
 
   return ez('div').append(
     (statusElement = new StatusElement(false)),
-
     new EZButton(() => {
       statusElement.enable();
     }).append(

--- a/examples/src/ez-textinput-example/EZTextInputExample.ts
+++ b/examples/src/ez-textinput-example/EZTextInputExample.ts
@@ -8,9 +8,7 @@ export function EZTextInputExample() {
     (textInput = new EZTextInput((newValue: string) => {
       statusElement.setTextContent(`Input value: ${newValue}`);
     })),
-
     (statusElement = ez('div')),
-
     ez('button')
       .setTextContent('Set to "Foo"')
       .onClick(() => {

--- a/examples/src/jsx-example/JSXExample.tsx
+++ b/examples/src/jsx-example/JSXExample.tsx
@@ -1,4 +1,4 @@
-import * as EZJSX from 'ez-elements';
+import * as EZJSX from '@ez-elements/jsx';
 import { AnyEZElement, EZDiv, EZElement } from 'ez-elements';
 
 // "jsx": "react", in tsconfig.json means that JSX tags are transformed into

--- a/examples/src/shadow-example/list/FilterableStaticList.ts
+++ b/examples/src/shadow-example/list/FilterableStaticList.ts
@@ -46,7 +46,6 @@ export class FilterableStaticList extends EZShadowElement<'div'> {
       (this.input = new EZTextInput(value => {
         this.applyFilter(value);
       }).addClass(textInputClassName)),
-
       ez('div').append(
         new EZButton(() => {
           this.input.setValue('1');

--- a/ez-elements/package.json
+++ b/ez-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-elements",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -13,10 +13,9 @@
   "author": "Marcus Longmuir",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ez-elements/core": "^0.0.4",
-    "@ez-elements/inputs": "^0.0.4",
-    "@ez-elements/jsx": "^0.0.4",
-    "@ez-elements/shadow": "^0.0.4"
+    "@ez-elements/core": "^0.0.5",
+    "@ez-elements/inputs": "^0.0.5",
+    "@ez-elements/shadow": "^0.0.5"
   },
   "gitHead": "65f90fac77403cb79d7f33656daa500ae0eb66b4"
 }

--- a/ez-elements/src/index.spec.ts
+++ b/ez-elements/src/index.spec.ts
@@ -12,9 +12,6 @@ describe('ez-elements', () => {
     expect(whole.EZButton).toBeInstanceOf(Function);
     expect(whole.EZTextInput).toBeInstanceOf(Function);
 
-    // jsx
-    expect(whole.JSX).toBeInstanceOf(Function);
-
     // shadow
     expect(whole.extractStyleContents).toBeInstanceOf(Function);
     expect(whole.EZShadowElement).toBeInstanceOf(Function);

--- a/ez-elements/src/index.ts
+++ b/ez-elements/src/index.ts
@@ -1,4 +1,3 @@
 export * from '@ez-elements/core';
 export * from '@ez-elements/inputs';
-export * from '@ez-elements/jsx';
 export * from '@ez-elements/shadow';

--- a/inputs/package.json
+++ b/inputs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ez-elements/inputs",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -16,10 +16,10 @@
   "author": "Marcus Longmuir",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@ez-elements/core": "^0.0.4"
+    "@ez-elements/core": "^0.0.5"
   },
   "devDependencies": {
-    "@ez-elements/core": "^0.0.4"
+    "@ez-elements/core": "^0.0.5"
   },
   "gitHead": "65f90fac77403cb79d7f33656daa500ae0eb66b4"
 }

--- a/jsx/package.json
+++ b/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ez-elements/jsx",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -16,10 +16,10 @@
   "author": "Marcus Longmuir",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@ez-elements/core": "^0.0.4"
+    "@ez-elements/core": "^0.0.5"
   },
   "devDependencies": {
-    "@ez-elements/core": "^0.0.4"
+    "@ez-elements/core": "^0.0.5"
   },
   "gitHead": "65f90fac77403cb79d7f33656daa500ae0eb66b4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2590,9 +2590,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true,
       "optional": true
     },
@@ -4712,9 +4712,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,8 @@ Alternatively, you can install just the parts of the package that you want:
 
 * `@ez-elements/core` contains `ez`, `EZElement`, `EZDiv` and `EZSpan`.
 * `@ez-elements/inputs` contains `EZTextInput` and `EZButton`.
-* `@ez-elements/jsx` contains `JSX`.
 * `@ez-elements/shadow` contains `EZShadowElement` and `extractStyleContents`.
+* `@ez-elements/jsx` contains `JSX` (and is not included in `ez-elements`).
 
 ## Getting Started
 

--- a/shadow/package.json
+++ b/shadow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ez-elements/shadow",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
@@ -16,10 +16,10 @@
   "author": "Marcus Longmuir",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@ez-elements/core": "^0.0.4"
+    "@ez-elements/core": "^0.0.5"
   },
   "devDependencies": {
-    "@ez-elements/core": "^0.0.4",
+    "@ez-elements/core": "^0.0.5",
     "document-register-element": "^1.14.3",
     "jest-environment-jsdom-fifteen": "^1.0.0"
   },


### PR DESCRIPTION
As the JSX namespace declaration conflicts with React's declaration (making it difficult to use `ez-elements` alongside `react` even if you aren't using JSX) I'm removing it from the `ez-elements` package.

It can still be installed separately as `@ez-elements/jsx`.